### PR TITLE
Phase 2.2: Multi-Editor Support

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -12,7 +12,12 @@
     "Terminal"
   ],
   
-  "editor": "VSCodium",
+  "editors": [
+    "VSCodium",
+    "Visual Studio Code",
+    "Cursor",
+    "Zed"
+  ],
   
   "logging": {
     "enabled": true,
@@ -29,13 +34,13 @@
   
   "_comments": {
     "terminals": "List of terminal applications to show in picker (in order). Only installed apps will be shown.",
-    "editor": "Default editor application. Set to empty string to disable editor prompts.",
+    "editors": "List of editor applications. If multiple editors are configured, you'll be asked to choose. Set to empty list [] to disable editor prompts. Set to single-item list to skip picker dialog.",
     "logging.enabled": "Enable or disable file logging.",
     "logging.level": "Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL",
     "logging.file": "Path to log file. Tilde (~) expands to user home directory.",
     "logging.max_bytes": "Maximum size of log file before rotation (in bytes). Default: 1MB",
     "logging.backup_count": "Number of backup log files to keep. Default: 7",
-    "behavior.auto_open_editor": "If true, show editor prompt after terminal selection.",
+    "behavior.auto_open_editor": "If true, show editor prompt after terminal selection. If false, skip editor entirely.",
     "behavior.remember_choices": "If true, remember last terminal/editor choice per project (Phase 2.4 feature)."
   }
 }


### PR DESCRIPTION
## Phase 2.2: Multi-Editor Support ✅

Implements support for multiple editors with intelligent picker dialogs.

### New Features

**Multi-Editor System**
- ✅ Config now uses `editors` array instead of single `editor`
- ✅ Single editor: Simple Yes/No dialog (like before)
- ✅ Multiple editors: Picker dialog with "None" option
- ✅ Empty editors list: Skip editor prompt entirely
- ✅ Backward compatibility: Old `editor` config auto-converts

**Smart Dialogs**
- ✅ 1 editor → "Open in VSCodium?" (Yes/No)
- ✅ 2+ editors → "Choose editor" picker with None option
- ✅ 0 editors → Silent skip (no annoying dialogs)
- ✅ Only installed editors shown

**Enhanced Test Mode**
- ✅ Shows all configured editors
- ✅ Indicates which are installed
- ✅ Notes if picker dialog will appear

### Configuration Example

```json
{
  "editors": [
    "VSCodium",
    "Visual Studio Code",
    "Cursor",
    "Zed"
  ]
}
```

**Or disable editors entirely:**
```json
{
  "editors": []
}
```

### Backward Compatibility

Old config format still works! This:
```json
{
  "editor": "VSCodium"
}
```

Auto-converts to:
```json
{
  "editors": ["VSCodium"]
}
```

### Test Commands

```bash
# Test with default config
python3 open_dev_env.py --test --verbose

# Edit config to add multiple editors
nano ~/.config/macos-dev-launcher/config.json
# Change "editor": "VSCodium" to:
# "editors": ["VSCodium", "Visual Studio Code", "Cursor", "Zed"]

# Test it!
python3 open_dev_env.py ~/github_repo/macos-dev-launcher
# You'll get a picker dialog if multiple editors are installed
```

### Implementation Details

**Added:**
- `get_available_editors()` function (like terminals)
- `ask_editor_choice()` replaces `ask_open_editor()`
- Backward compatibility for old `editor` config
- Enhanced test mode for editors

**Changed:**
- Config uses `editors` list instead of `editor` string
- Editor selection now shows picker for multiple editors
- "None" option in picker for terminal-only workflow
- Empty editor list skips prompts entirely

**Dialog Behavior:**
- Single editor: Yes/No dialog (quick and familiar)
- Multiple editors: Picker with None option (flexible)
- No editors: Silent skip (clean UX)

**Estimated Effort:** 2-3 hours  
**Actual Effort:** ~2 hours

### Roadmap Progress

- [x] Phase 1 - Foundation & Robustness (COMPLETE)
- [x] Phase 2.1 - External Configuration File (COMPLETE)
- [x] Phase 2.2 - Multi-Editor Support
- [ ] Phase 2.3 - Custom Launch Arguments
- [ ] Phase 2.4 - Memory/Favorites System

**One step closer to Phase 2 completion!** 🎯